### PR TITLE
Make sure flushing the client queue flushes the entire queue

### DIFF
--- a/lib/ldclient-rb/ldclient.rb
+++ b/lib/ldclient-rb/ldclient.rb
@@ -48,12 +48,11 @@ module LaunchDarkly
 
     def flush
       events = []
-      num_events = @queue.length
       begin
-        num_events.times do
+        while true
           events << @queue.pop(true)
         end
-      rescue
+      rescue ThreadError
       end
 
       if !events.empty?

--- a/spec/ldclient_spec.rb
+++ b/spec/ldclient_spec.rb
@@ -2,4 +2,33 @@ require 'spec_helper'
 
 describe LaunchDarkly::LDClient do
   subject { LaunchDarkly::LDClient }
+  let(:client) do
+    expect_any_instance_of(LaunchDarkly::LDClient).to receive :create_worker
+    subject.new('api_key')
+  end
+
+  describe '#flush' do
+    it 'will flush and post all events' do
+      client.instance_variable_get(:@queue).push 'asdf'
+      client.instance_variable_get(:@queue).push 'asdf'
+      result = double('result', status: 200)
+      expect(client.instance_variable_get(:@client)).to receive(:post).and_return result
+      client.flush
+      expect(client.instance_variable_get(:@queue).length).to eq 0
+    end
+    it 'will work with unexpected post results' do
+      client.instance_variable_get(:@queue).push 'asdf'
+      client.instance_variable_get(:@queue).push 'asdf'
+      result = double('result', status: 500)
+      expect(client.instance_variable_get(:@client)).to receive(:post).and_return result
+      expect(client.instance_variable_get(:@config).logger).to receive :error
+      client.flush
+      expect(client.instance_variable_get(:@queue).length).to eq 0
+    end
+    it 'will not do anything if there are no events' do
+      expect(client.instance_variable_get(:@client)).to_not receive(:post)
+      expect(client.instance_variable_get(:@config).logger).to_not receive :error
+      client.flush
+    end
+  end
 end


### PR DESCRIPTION
`@queue` itself may be threadsafe, but the code that flushes it may not be, since it will only pop off a number of elements in a past amount of time.  