### PR TITLE
Reduce logging level for stream issues

### DIFF
--- a/lib/ldclient-rb/stream.rb
+++ b/lib/ldclient-rb/stream.rb
@@ -130,7 +130,7 @@ module LaunchDarkly
       source.on PATCH { |message| process_message(message, PATCH) }
       source.on DELETE { |message| process_message(message, DELETE) }
       source.error do |error|
-        @config.logger.error("[LDClient] Error subscribing to stream API: #{error}")
+        @config.logger.info("[LDClient] Error subscribing to stream API: #{error}")
         set_disconnected
       end
       source.inactivity_timeout = 0


### PR DESCRIPTION
Disconnects from the stream API are normal behavior. Reduce logging level around stream issues to reflect this.