### PR TITLE
Check for nil never sets the value to default

### DIFF
--- a/lib/ldclient-rb/ldclient.rb
+++ b/lib/ldclient-rb/ldclient.rb
@@ -144,7 +144,7 @@ module LaunchDarkly
         feature = get_flag_int(key)
       end
       value = evaluate(feature, user)
-      value.nil? ? default : value
+      value = value.nil? ? default : value
 
       add_event(kind: "feature", key: key, user: user, value: value)
       LDNewRelic.annotate_transaction(key, value)


### PR DESCRIPTION
I discovered that when a feature is off in the UI the gem will return nil instead of the default. Looking in the code I see there is a check for it but it never gets assigned to the `value` variable.