### PR TITLE
Add update_user_flag_setting method in new Settings module

### DIFF
--- a/lib/ldclient-rb.rb
+++ b/lib/ldclient-rb.rb
@@ -1,4 +1,5 @@
 require "ldclient-rb/version"
+require "ldclient-rb/settings"
 require "ldclient-rb/ldclient"
 require "ldclient-rb/store"
 require "ldclient-rb/config"

--- a/lib/ldclient-rb/ldclient.rb
+++ b/lib/ldclient-rb/ldclient.rb
@@ -16,6 +16,7 @@ module LaunchDarkly
   #
   #
   class LDClient
+    include Settings
     #
     # Creates a new client instance that connects to LaunchDarkly. A custom
     # configuration parameter can also supplied to specify advanced options,

--- a/lib/ldclient-rb/settings.rb
+++ b/lib/ldclient-rb/settings.rb
@@ -1,0 +1,40 @@
+module LaunchDarkly
+
+  #
+  # Module to manage user flag settings
+  #
+  module Settings
+    #
+    # Specifically enable or disable a feature flag for a user based
+    # on their key.
+    #
+    # @param user_key [String] the key of the user
+    # @param flag_key [String] the unique feature key for the feature flag, as shown
+    #   on the LaunchDarkly dashboard
+    # @param setting [Boolean] the new setting, one of:
+    #    true: the feature is always on
+    #    false: the feature is never on
+    #    nil: remove the setting (assign user per defined rules)
+    def update_user_flag_setting(user_key, flag_key, setting=nil)
+      unless user_key
+        @config.logger.error("[LDClient] Must specify user")
+        return
+      end      
+      
+      res = log_timings('update_user_flag_setting') do
+        @client.put("#{@config.base_uri}/api/users/#{user_key}/features/#{flag_key}") do |req|
+          req.headers['Authorization'] = "api_key #{@api_key}"
+          req.headers['User-Agent'] = "RubyClient/#{LaunchDarkly::VERSION}"
+          req.headers['Content-Type'] = 'application/json'
+          req.body = {setting: setting}.to_json
+          req.options.timeout = @config.read_timeout
+          req.options.open_timeout = @config.connect_timeout
+        end
+      end
+
+      unless res.success?
+        @config.logger.error("[LDClient] Failed to change setting, status: #{res.status}")
+      end
+    end
+  end
+end

--- a/spec/ldclient_spec.rb
+++ b/spec/ldclient_spec.rb
@@ -15,6 +15,21 @@ describe LaunchDarkly::LDClient do
     JSON.parse(data, symbolize_names: true)
   end
 
+  context 'user flag settings' do
+    describe '#update_user_flag_setting' do
+      it 'requires user' do
+        expect(client.instance_variable_get(:@config).logger).to receive(:error)
+        client.update_user_flag_setting(nil, feature[:key], true)
+      end
+
+      it 'puts the new setting' do
+        result = double('result', success?: true, status: 204)
+        expect(client.instance_variable_get(:@client)).to receive(:put).and_return(result)
+        client.update_user_flag_setting(user[:key], feature[:key], true)
+      end
+    end
+  end
+
   describe '#flush' do
     it "will flush and post all events" do
       client.instance_variable_get(:@queue).push "asdf"


### PR DESCRIPTION
Here's a method for managing user flag settings. I thought it might make sense to have in a separate module in case you want to treat this API differently from the flag APIs.