### PR TITLE
Switch to celluloid-based eventsource implementation

### DIFF
--- a/ldclient-rb.gemspec
+++ b/ldclient-rb.gemspec
@@ -30,5 +30,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "net-http-persistent", "~> 2.9"
   spec.add_runtime_dependency "concurrent-ruby", "~> 1.0.0"
   spec.add_runtime_dependency "hashdiff", "~> 0.2"
-  spec.add_runtime_dependency "ld-em-eventsource", "~> 0.2"
+  #spec.add_runtime_dependency "ld-em-eventsource", "~> 0.2"
+  spec.add_runtime_dependency "celluloid-eventsource", "~> 0.3" 
 end

--- a/ldclient-rb.gemspec
+++ b/ldclient-rb.gemspec
@@ -31,5 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "concurrent-ruby", "~> 1.0.0"
   spec.add_runtime_dependency "hashdiff", "~> 0.2"
   #spec.add_runtime_dependency "ld-em-eventsource", "~> 0.2"
-  spec.add_runtime_dependency "celluloid-eventsource", "~> 0.3" 
+  spec.add_runtime_dependency "ld-celluloid-eventsource", "~> 0.4" 
 end

--- a/lib/ldclient-rb/stream.rb
+++ b/lib/ldclient-rb/stream.rb
@@ -95,6 +95,8 @@ module LaunchDarkly
     end
 
     def start
+      return unless @started.make_true
+      
       headers = 
       {
         'Authorization' => 'api_key ' + @api_key,

--- a/lib/ldclient-rb/stream.rb
+++ b/lib/ldclient-rb/stream.rb
@@ -112,7 +112,7 @@ module LaunchDarkly
 
         conn.on_error do |message|
           # TODO replace this with proper logging
-          @config.logger.error("[LDClient] Error message #{message[:status_code]}, Response body #{message[:body]}")
+          @config.logger.error("[LDClient] Error connecting to stream. Status code: #{message[:status_code]}")
           set_disconnected
         end
       end

--- a/spec/stream_spec.rb
+++ b/spec/stream_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require 'ostruct'
 
 describe LaunchDarkly::InMemoryFeatureStore do
   subject { LaunchDarkly::InMemoryFeatureStore }
@@ -35,9 +36,9 @@ describe LaunchDarkly::StreamProcessor do
   let(:processor) { subject.new("api_key", config) }
 
   describe '#process_message' do
-    let(:put_message) { {data: '{"key": {"value": "asdf"}}'} }
-    let(:patch_message) { {data: '{"path": "akey", "data": {"value": "asdf", "version": 1}}'} }
-    let(:delete_message) { {data: '{"path": "akey", "version": 2}'} }
+    let(:put_message) { OpenStruct.new({data: '{"key": {"value": "asdf"}}'}) }
+    let(:patch_message) { OpenStruct.new({data: '{"path": "akey", "data": {"value": "asdf", "version": 1}}'}) }
+    let(:delete_message) { OpenStruct.new({data: '{"path": "akey", "version": 2}'}) }
     it "will accept PUT methods" do
       processor.send(:process_message, put_message, LaunchDarkly::PUT)
       expect(processor.instance_variable_get(:@store).get("key")).to eq(value: "asdf")

--- a/spec/stream_spec.rb
+++ b/spec/stream_spec.rb
@@ -35,9 +35,9 @@ describe LaunchDarkly::StreamProcessor do
   let(:processor) { subject.new("api_key", config) }
 
   describe '#process_message' do
-    let(:put_message) { '{"key": {"value": "asdf"}}' }
-    let(:patch_message) { '{"path": "akey", "data": {"value": "asdf", "version": 1}}' }
-    let(:delete_message) { '{"path": "akey", "version": 2}' }
+    let(:put_message) { {data: '{"key": {"value": "asdf"}}'} }
+    let(:patch_message) { {data: '{"path": "akey", "data": {"value": "asdf", "version": 1}}'} }
+    let(:delete_message) { {data: '{"path": "akey", "version": 2}'} }
     it "will accept PUT methods" do
       processor.send(:process_message, put_message, LaunchDarkly::PUT)
       expect(processor.instance_variable_get(:@store).get("key")).to eq(value: "asdf")

--- a/spec/stream_spec.rb
+++ b/spec/stream_spec.rb
@@ -33,50 +33,6 @@ describe LaunchDarkly::StreamProcessor do
   subject { LaunchDarkly::StreamProcessor }
   let(:config) { LaunchDarkly::Config.new }
   let(:processor) { subject.new("api_key", config) }
-  describe '#start' do
-    it "will check if the reactor has started" do
-      expect(processor).to receive(:start_reactor).and_return false
-      expect(EM).to_not receive(:defer)
-      processor.start
-    end
-    it "will check if the stream processor has already started" do
-      expect(processor).to receive(:start_reactor).and_return true
-      processor.instance_variable_get(:@started).make_true
-      expect(EM).to_not receive(:defer)
-      processor.start
-    end
-    it "will boot the stream processor" do
-      expect(processor).to receive(:start_reactor).and_return true
-      expect(EM).to receive(:defer)
-      processor.start
-    end
-  end
-
-  describe '#boot_event_manager' do
-    let(:message) { "asdf" }
-    before do
-      processor.instance_variable_get(:@config).instance_variable_set(:@stream_uri, "http://example.com/streaming")
-      expect_any_instance_of(EM::EventSource).to receive(:start)
-      source = processor.send(:boot_event_manager)
-      @req = source.instance_variable_get "@req"
-      # It seems  testing EventManager is hard/impossible
-    end
-    it "will start" do
-    end
-    xit "will process put messages" do
-      expect(processor).to receive(:process_message).with(message, LaunchDarkly::PUT)
-      @req.stream_data("data: #{message}\nevent:#{LaunchDarkly::PUT}\n")
-    end
-    xit "will process patch messages" do
-      expect(processor).to receive(:process_message).with(message, LaunchDarkly::PATCH)
-    end
-    xit "will process delete messages" do
-      expect(processor).to receive(:process_message).with(message, LaunchDarkly::DELETE)
-    end
-    xit "will process errors" do
-      expect(processor).to receive(:set_disconnected)
-    end
-  end
 
   describe '#process_message' do
     let(:put_message) { '{"key": {"value": "asdf"}}' }


### PR DESCRIPTION
This eliminates our dependency on EventMachine and replaces it with a Celluloid-based library for EventSource