### PR TITLE
Auto-register user within #get_user_settings as well

### DIFF
--- a/lib/ldclient-rb/ldclient.rb
+++ b/lib/ldclient-rb/ldclient.rb
@@ -238,6 +238,9 @@ module LaunchDarkly
     end
 
     def get_user_settings(user)
+      # Auto-register the user similar to "toggle?"
+      identify(user)
+
       Hash[all_flags.map { |key, feature| [key, evaluate(feature, user)]}]
     end
 

--- a/spec/ldclient_spec.rb
+++ b/spec/ldclient_spec.rb
@@ -126,6 +126,13 @@ describe LaunchDarkly::LDClient do
     end
   end
 
+  describe '#get_user_settings' do
+    it "calls identify to register the user" do
+      expect(client).to receive(:identify).with(user)
+      client.get_user_settings(user)
+    end
+  end
+
   describe '#track' do 
     it "queues up an custom event" do
       expect(client).to receive(:add_event).with(hash_including(kind: "custom", key: "custom_event_name", user: user, data: 42))


### PR DESCRIPTION
In our current use case, we're using `get_user_settings` to expose all flags for a given user at once. For the most part, that works great.

However, `toggle?` has the nice side-effect of auto-registering the users we call it with, which we don't get to have with this method. Calling `identify` for each user we want to get all flags of (whether at the time of the call or on a schedule) seems like a weird divergence from how `toggle?` _Just Works_ ™️ 

I didn't want to call `add_event` directly, as `identify` does exactly the thing that we're looking for here, so I just delegated that.

This would be super helpful. Let me know if I'm missing something.
