### PR TITLE
Bump faraday-http-cache version

### DIFF
--- a/ldclient-rb.gemspec
+++ b/ldclient-rb.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "json", "~> 1.8"
   spec.add_runtime_dependency "faraday", "~> 0.9"
-  spec.add_runtime_dependency "faraday-http-cache", "= 1.3.0"
+  spec.add_runtime_dependency "faraday-http-cache", "~> 1.3.0"
   spec.add_runtime_dependency "thread_safe", "~> 0.3"
   spec.add_runtime_dependency "net-http-persistent", "~> 2.9"
   spec.add_runtime_dependency "concurrent-ruby", "~> 1.0.0"

--- a/ldclient-rb.gemspec
+++ b/ldclient-rb.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "json", "~> 1.8"
   spec.add_runtime_dependency "faraday", "~> 0.9"
-  spec.add_runtime_dependency "faraday-http-cache", "~> 0.4"
+  spec.add_runtime_dependency "faraday-http-cache", "= 1.3.0"
   spec.add_runtime_dependency "thread_safe", "~> 0.3"
   spec.add_runtime_dependency "net-http-persistent", "~> 2.9"
   spec.add_runtime_dependency "concurrent-ruby", "~> 1.0.0"

--- a/lib/ldclient-rb/store.rb
+++ b/lib/ldclient-rb/store.rb
@@ -35,5 +35,12 @@ module LaunchDarkly
     def write(key, value)
       @cache[key] = value
     end
+
+    #
+    # Delete a value in the cache
+    # @param key [Object] the cache key
+    def delete(key)
+      @cache.delete(key)
+    end
   end
 end


### PR DESCRIPTION
Fixes #61 

Bumping the version caused an issue with LaunchDarkly::ThreadSafeMemoryStore not implementing a delete method.

Implemented the delete method - tests pass.

UAT'ed the gem locally for using feature toggles and the toggle? method. Haven't done any further testing in that regard.

Running the gem in production now without further issues.