### PR TITLE
Add http proxy support

### DIFF
--- a/ldclient-rb.gemspec
+++ b/ldclient-rb.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "net-http-persistent", "~> 2.9"
   spec.add_runtime_dependency "concurrent-ruby", "~> 1.0.4"
   spec.add_runtime_dependency "hashdiff", "~> 0.2"
-  spec.add_runtime_dependency "ld-celluloid-eventsource", "~> 0.9.0"
+  spec.add_runtime_dependency "ld-celluloid-eventsource", "~> 0.10.0"
   spec.add_runtime_dependency "celluloid", "~> 0.18.0.pre" # transitive dep; specified here for more control
   
   if RUBY_VERSION >= '2.2.2'

--- a/lib/ldclient-rb/config.rb
+++ b/lib/ldclient-rb/config.rb
@@ -145,7 +145,7 @@ module LaunchDarkly
     attr_reader :feature_store
 
     
-    # The proxy configuration
+    # The proxy configuration string
     #
     attr_reader :proxy
 

--- a/lib/ldclient-rb/config.rb
+++ b/lib/ldclient-rb/config.rb
@@ -56,6 +56,7 @@ module LaunchDarkly
       @stream = opts.has_key?(:stream) ? opts[:stream] : Config.default_stream
       @offline = opts.has_key?(:offline) ? opts[:offline] : Config.default_offline
       @poll_interval = opts.has_key?(:poll_interval) && opts[:poll_interval] > 1 ? opts[:poll_interval] : Config.default_poll_interval
+      @proxy = opts[:proxy] || Config.default_proxy
     end
 
     #
@@ -143,6 +144,11 @@ module LaunchDarkly
     #
     attr_reader :feature_store
 
+    
+    # The proxy configuration
+    #
+    attr_reader :proxy
+
     #
     # The default LaunchDarkly client configuration. This configuration sets
     # reasonable defaults for most users.
@@ -182,6 +188,10 @@ module LaunchDarkly
 
     def self.default_connect_timeout
       2
+    end
+
+    def self.default_proxy
+      nil
     end
 
     def self.default_logger

--- a/lib/ldclient-rb/requestor.rb
+++ b/lib/ldclient-rb/requestor.rb
@@ -30,6 +30,9 @@ module LaunchDarkly
         req.headers["User-Agent"] = "RubyClient/" + LaunchDarkly::VERSION
         req.options.timeout = @config.read_timeout
         req.options.open_timeout = @config.connect_timeout
+        if @config.proxy
+          req.options.proxy = Faraday::ProxyOptions.from @config.proxy
+        end
       end
 
       @config.logger.debug("[LDClient] Got response from uri: #{uri}\n\tstatus code: #{res.status}\n\theaders: #{res.headers}\n\tbody: #{res.body}")

--- a/lib/ldclient-rb/stream.rb
+++ b/lib/ldclient-rb/stream.rb
@@ -33,7 +33,7 @@ module LaunchDarkly
         'Authorization' => @sdk_key,
         'User-Agent' => 'RubyClient/' + LaunchDarkly::VERSION
       }
-      opts = {:headers => headers, :with_credentials => true}
+      opts = {:headers => headers, :with_credentials => true, :proxy => @config.proxy}
       @es = Celluloid::EventSource.new(@config.stream_uri + "/flags", opts) do |conn|
         conn.on(PUT) { |message| process_message(message, PUT) }
         conn.on(PATCH) { |message| process_message(message, PATCH) }

--- a/spec/requestor_spec.rb
+++ b/spec/requestor_spec.rb
@@ -1,0 +1,53 @@
+require "spec_helper"
+require "faraday"
+
+describe LaunchDarkly::Requestor do
+  describe ".request_all_flags" do
+    describe "with a proxy" do
+      let(:requestor) {
+        LaunchDarkly::Requestor.new(
+          "key",
+          LaunchDarkly::Config.new({
+            :proxy => "http://proxy.com",
+            :base_uri => "http://ld.com"
+          })
+        )
+      }
+      it "converts the proxy option" do
+        faraday = Faraday.new
+        requestor.instance_variable_set(:@client, faraday)
+        allow(faraday).to receive(:get) do |*args, &block|
+          req = double(Faraday::Request, :headers => {}, :options => Faraday::RequestOptions.new)
+          block.call(req)
+          expect(args).to eq ['http://ld.com/sdk/latest-flags']
+          expect(req.options.proxy[:uri]).to eq URI("http://proxy.com")
+          double(body: '{"foo": "bar"}', status: 200, headers: {})
+        end
+
+        requestor.request_all_flags()
+      end
+    end
+    describe "without a proxy" do
+      let(:requestor) {
+        LaunchDarkly::Requestor.new(
+          "key",
+          LaunchDarkly::Config.new({
+            :base_uri => "http://ld.com"
+          })
+        )
+      }
+      it "converts the proxy option" do
+        faraday = Faraday.new
+        requestor.instance_variable_set(:@client, faraday)
+        allow(faraday).to receive(:get) do |*args, &block|
+          req = double(Faraday::Request, :headers => {}, :options => Faraday::RequestOptions.new)
+          block.call(req)
+          expect(args).to eq ['http://ld.com/sdk/latest-flags']
+          expect(req.options.proxy).to eq nil
+          double(body: '{"foo": "bar"}', status: 200, headers: {})
+        end
+        requestor.request_all_flags()
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds proxy support to the ruby sdk.

The new configuration option is as follows:

```rb
{ :proxy => "protocol://url:port" }
```

With this change:

1) HTTP Proxies are configurable via the above parameter.
2) HTTP Proxies are also configurable via the `HTTP_PROXY` and `http_proxy` environment variables.