### PR TITLE
Update ld-celluloid-eventsource to ~> 0.11.0

### DIFF
--- a/ldclient-rb.gemspec
+++ b/ldclient-rb.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "net-http-persistent", "~> 2.9"
   spec.add_runtime_dependency "concurrent-ruby", "~> 1.0.4"
   spec.add_runtime_dependency "hashdiff", "~> 0.2"
-  spec.add_runtime_dependency "ld-celluloid-eventsource", "~> 0.10.0"
+  spec.add_runtime_dependency "ld-celluloid-eventsource", "~> 0.11.0"
   spec.add_runtime_dependency "celluloid", "~> 0.18.0.pre" # transitive dep; specified here for more control
 
   if RUBY_VERSION >= "2.2.2"


### PR DESCRIPTION
As a follow-up to [this bug report][bug] and [this release][release], I believe it's possible to upgrade the `ld-celluloid-eventsource` dependency of this gem to use this version matcher: `~> 0.11.0`

All tests seem to pass locally with Ruby 2.4.1.

[bug]: https://github.com/launchdarkly/ruby-client/issues/91
[release]: https://github.com/launchdarkly/celluloid-eventsource/pull/8