### PR TITLE
Use Logger block form calls

### DIFF
--- a/lib/ldclient-rb/evaluation.rb
+++ b/lib/ldclient-rb/evaluation.rb
@@ -156,7 +156,7 @@ module LaunchDarkly
               failed_prereq = true
             end
           rescue => exn
-            @config.logger.error("[LDClient] Error evaluating prerequisite: #{exn.inspect}")
+            @config.logger.error { "[LDClient] Error evaluating prerequisite: #{exn.inspect}" }
             failed_prereq = true
           end
         end

--- a/lib/ldclient-rb/events.rb
+++ b/lib/ldclient-rb/events.rb
@@ -50,9 +50,9 @@ module LaunchDarkly
         req.options.open_timeout = @config.connect_timeout
       end
       if res.status < 200 || res.status >= 300
-        @config.logger.error("[LDClient] Unexpected status code while processing events: #{res.status}")
+        @config.logger.error { "[LDClient] Unexpected status code while processing events: #{res.status}" }
         if res.status == 401
-          @config.logger.error("[LDClient] Received 401 error, no further events will be posted since SDK key is invalid")
+          @config.logger.error { "[LDClient] Received 401 error, no further events will be posted since SDK key is invalid" }
           stop
         end
       end
@@ -78,14 +78,14 @@ module LaunchDarkly
 
       if @queue.length < @config.capacity
         event[:creationDate] = (Time.now.to_f * 1000).to_i
-        @config.logger.debug("[LDClient] Enqueueing event: #{event.to_json}")
+        @config.logger.debug { "[LDClient] Enqueueing event: #{event.to_json}" }
         @queue.push(event)
 
         if !@worker.alive?
           @worker = create_worker
         end
       else
-        @config.logger.warn("[LDClient] Exceeded event queue capacity. Increase capacity to avoid dropping events.")
+        @config.logger.warn { "[LDClient] Exceeded event queue capacity. Increase capacity to avoid dropping events." }
       end
     end
 

--- a/lib/ldclient-rb/polling.rb
+++ b/lib/ldclient-rb/polling.rb
@@ -17,7 +17,7 @@ module LaunchDarkly
 
     def start
       return unless @started.make_true
-      @config.logger.info("[LDClient] Initializing polling connection")
+      @config.logger.info { "[LDClient] Initializing polling connection" }
       create_worker
     end
 
@@ -26,7 +26,7 @@ module LaunchDarkly
         if @worker && @worker.alive?
           @worker.raise "shutting down client"
         end
-        @config.logger.info("[LDClient] Polling connection stopped")
+        @config.logger.info { "[LDClient] Polling connection stopped" }
       end
     end
 
@@ -38,14 +38,14 @@ module LaunchDarkly
           SEGMENTS => all_data[:segments]
         })
         if @initialized.make_true
-          @config.logger.info("[LDClient] Polling connection initialized")
+          @config.logger.info { "[LDClient] Polling connection initialized" }
         end
       end
     end
 
     def create_worker
       @worker = Thread.new do
-        @config.logger.debug("[LDClient] Starting polling worker")
+        @config.logger.debug { "[LDClient] Starting polling worker" }
         while !@stopped.value do
           begin
             started_at = Time.now
@@ -55,10 +55,10 @@ module LaunchDarkly
               sleep(delta)
             end
           rescue InvalidSDKKeyError
-            @config.logger.error("[LDClient] Received 401 error, no further polling requests will be made since SDK key is invalid");
+            @config.logger.error { "[LDClient] Received 401 error, no further polling requests will be made since SDK key is invalid" };
             stop
           rescue StandardError => exn
-            @config.logger.error("[LDClient] Exception while polling: #{exn.inspect}")
+            @config.logger.error { "[LDClient] Exception while polling: #{exn.inspect}" }
             # TODO: log_exception(__method__.to_s, exn)
           end
         end

--- a/lib/ldclient-rb/redis_store.rb
+++ b/lib/ldclient-rb/redis_store.rb
@@ -94,12 +94,12 @@ and prefix: #{@prefix}")
     def get(kind, key)
       f = @cache[cache_key(kind, key)]
       if f.nil?
-        @logger.debug("RedisFeatureStore: no cache hit for #{key} in '#{kind[:namespace]}', requesting from Redis")
+        @logger.debug { "RedisFeatureStore: no cache hit for #{key} in '#{kind[:namespace]}', requesting from Redis" }
         f = with_connection do |redis|
           begin
             get_redis(kind, redis, key.to_sym)
           rescue => e
-            @logger.error("RedisFeatureStore: could not retrieve #{key} from Redis in '#{kind[:namespace]}', with error: #{e}")
+            @logger.error { "RedisFeatureStore: could not retrieve #{key} from Redis in '#{kind[:namespace]}', with error: #{e}" }
             nil
           end
         end
@@ -108,10 +108,10 @@ and prefix: #{@prefix}")
         end
       end
       if f.nil?
-        @logger.debug("RedisFeatureStore: #{key} not found in '#{kind[:namespace]}'")
+        @logger.debug { "RedisFeatureStore: #{key} not found in '#{kind[:namespace]}'" }
         nil
       elsif f[:deleted]
-        @logger.debug("RedisFeatureStore: #{key} was deleted in '#{kind[:namespace]}', returning nil")
+        @logger.debug { "RedisFeatureStore: #{key} was deleted in '#{kind[:namespace]}', returning nil" }
         nil
       else
         f
@@ -124,7 +124,7 @@ and prefix: #{@prefix}")
         begin
           hashfs = redis.hgetall(items_key(kind))
         rescue => e
-          @logger.error("RedisFeatureStore: could not retrieve all '#{kind[:namespace]}' items from Redis with error: #{e}; returning none")
+          @logger.error { "RedisFeatureStore: could not retrieve all '#{kind[:namespace]}' items from Redis with error: #{e}; returning none" }
           hashfs = {}
         end
         hashfs.each do |k, jsonItem|
@@ -169,7 +169,7 @@ and prefix: #{@prefix}")
         end
       end
       @inited.set(true)
-      @logger.info("RedisFeatureStore: initialized with #{count} items")
+      @logger.info { "RedisFeatureStore: initialized with #{count} items" }
     end
 
     def upsert(kind, item)
@@ -219,7 +219,7 @@ and prefix: #{@prefix}")
         json_item = redis.hget(items_key(kind), key)
         JSON.parse(json_item, symbolize_names: true) if json_item
       rescue => e
-        @logger.error("RedisFeatureStore: could not retrieve #{key} from Redis, error: #{e}")
+        @logger.error { "RedisFeatureStore: could not retrieve #{key} from Redis, error: #{e}" }
         nil
       end
     end
@@ -232,7 +232,7 @@ and prefix: #{@prefix}")
       begin
         redis.hset(items_key(kind), key, item.to_json)
       rescue => e
-        @logger.error("RedisFeatureStore: could not store #{key} in Redis, error: #{e}")
+        @logger.error { "RedisFeatureStore: could not store #{key} in Redis, error: #{e}" }
       end
       put_cache(kind, key.to_sym, item)
     end

--- a/lib/ldclient-rb/requestor.rb
+++ b/lib/ldclient-rb/requestor.rb
@@ -42,20 +42,20 @@ module LaunchDarkly
         end
       end
 
-      @config.logger.debug("[LDClient] Got response from uri: #{uri}\n\tstatus code: #{res.status}\n\theaders: #{res.headers}\n\tbody: #{res.body}")
+      @config.logger.debug { "[LDClient] Got response from uri: #{uri}\n\tstatus code: #{res.status}\n\theaders: #{res.headers}\n\tbody: #{res.body}" }
 
       if res.status == 401
-        @config.logger.error("[LDClient] Invalid SDK key")
+        @config.logger.error { "[LDClient] Invalid SDK key" }
         raise InvalidSDKKeyError
       end
 
       if res.status == 404
-        @config.logger.error("[LDClient] Resource not found")
+        @config.logger.error { "[LDClient] Resource not found" }
         return nil
       end
 
       if res.status < 200 || res.status >= 300
-        @config.logger.error("[LDClient] Unexpected status code #{res.status}")
+        @config.logger.error { "[LDClient] Unexpected status code #{res.status}" }
         return nil
       end
 

--- a/lib/ldclient-rb/stream.rb
+++ b/lib/ldclient-rb/stream.rb
@@ -33,7 +33,7 @@ module LaunchDarkly
     def start
       return unless @started.make_true
 
-      @config.logger.info("[LDClient] Initializing stream connection")
+      @config.logger.info { "[LDClient] Initializing stream connection" }
       
       headers = 
       {
@@ -48,9 +48,9 @@ module LaunchDarkly
         conn.on(INDIRECT_PUT) { |message| process_message(message, INDIRECT_PUT) }
         conn.on(INDIRECT_PATCH) { |message| process_message(message, INDIRECT_PATCH) }
         conn.on_error { |err|
-          @config.logger.error("[LDClient] Unexpected status code #{err[:status_code]} from streaming connection")
+          @config.logger.error { "[LDClient] Unexpected status code #{err[:status_code]} from streaming connection" }
           if err[:status_code] == 401
-            @config.logger.error("[LDClient] Received 401 error, no further streaming connection will be made since SDK key is invalid")
+            @config.logger.error { "[LDClient] Received 401 error, no further streaming connection will be made since SDK key is invalid" }
             stop
           end
         }
@@ -60,21 +60,21 @@ module LaunchDarkly
     def stop
       if @stopped.make_true
         @es.close
-        @config.logger.info("[LDClient] Stream connection stopped")
+        @config.logger.info { "[LDClient] Stream connection stopped" }
       end
     end
 
     def stop
       if @stopped.make_true
         @es.close
-        @config.logger.info("[LDClient] Stream connection stopped")
+        @config.logger.info { "[LDClient] Stream connection stopped" }
       end
     end
 
     private
 
     def process_message(message, method)
-      @config.logger.debug("[LDClient] Stream received #{method} message: #{message.data}")
+      @config.logger.debug { "[LDClient] Stream received #{method} message: #{message.data}" }
       if method == PUT
         message = JSON.parse(message.data, symbolize_names: true)
         @feature_store.init({
@@ -82,7 +82,7 @@ module LaunchDarkly
           SEGMENTS => message[:data][:segments]
         })
         @initialized.make_true
-        @config.logger.info("[LDClient] Stream initialized")
+        @config.logger.info { "[LDClient] Stream initialized" }
       elsif method == PATCH
         message = JSON.parse(message.data, symbolize_names: true)
         for kind in [FEATURES, SEGMENTS]
@@ -108,7 +108,7 @@ module LaunchDarkly
           SEGMENTS => all_data[:segments]
         })
         @initialized.make_true
-        @config.logger.info("[LDClient] Stream initialized (via indirect message)")
+        @config.logger.info { "[LDClient] Stream initialized (via indirect message)" }
       elsif method == INDIRECT_PATCH
         key = key_for_path(FEATURES, message.data)
         if key
@@ -120,7 +120,7 @@ module LaunchDarkly
           end
         end
       else
-        @config.logger.warn("[LDClient] Unknown message received: #{method}")
+        @config.logger.warn { "[LDClient] Unknown message received: #{method}" }
       end
     end
 


### PR DESCRIPTION
When blocks are used, and the set logging
level of the Logger object is above that of
the call, the block will not be executed.

This prevents string allocations in log
messages that would not be retained anyway,
which can be especially significant when
calling `inspect` on large-ish objects.

For rationale, see http://hawkins.io/2013/08/using-the-ruby-logger/
and https://stackoverflow.com/questions/30144317