### PR TITLE
rescue LoadError explicitly

### DIFF
--- a/lib/ldclient-rb/file_data_source.rb
+++ b/lib/ldclient-rb/file_data_source.rb
@@ -11,7 +11,7 @@ module LaunchDarkly
   begin
     require 'listen'
     @@have_listen = true
-  rescue
+  rescue LoadError
   end
   def self.have_listen?
     @@have_listen


### PR DESCRIPTION
`LoadError` is not a `StandardError` and therefore is not caught by a bare `rescue` block.