### PR TITLE
Update old requirement versions that cause Gemfile conflicts

### DIFF
--- a/ldclient-rb.gemspec
+++ b/ldclient-rb.gemspec
@@ -36,8 +36,8 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "faraday-http-cache", [">= 1.3.0", "< 3"]
   spec.add_runtime_dependency "semantic", "~> 1.6.0"
   spec.add_runtime_dependency "thread_safe", "~> 0.3"
-  spec.add_runtime_dependency "net-http-persistent", "~> 2.9"
-  spec.add_runtime_dependency "concurrent-ruby", "~> 1.0.4"
+  spec.add_runtime_dependency "net-http-persistent", "~> 3.0"
+  spec.add_runtime_dependency "concurrent-ruby", "~> 1.1.3"
   spec.add_runtime_dependency "hashdiff", "~> 0.2"
   spec.add_runtime_dependency "http_tools", '~> 0.4.5'
   spec.add_runtime_dependency "socketry", "~> 0.5.1"


### PR DESCRIPTION
I'm running into Gemfile conflicts trying to integrate this client into a Rails 5.2 application, because both `net-http-persistent` and `concurrent-ruby` are significantly out of date in this gem.